### PR TITLE
Users now have a username

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
      public const ADMIN = 'admin';
     protected $fillable = [
         'name',
+        'username',
         'email',
         'password',
         'role',

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('username')->unique();
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -19,6 +19,7 @@ class UserSeeder extends Seeder
         for ($i = 0; $i < 4; $i++) {
             User::create([
                 'name' => $faker->name(),
+                'username' => $faker->unique()->userName(),
                 'email' => $faker->unique()->safeEmail(),
                 'password' => bcrypt('password123'),
                 'role' => User::USER,
@@ -27,6 +28,7 @@ class UserSeeder extends Seeder
 
         User::create([
             'name' => 'admin',
+            'username' => 'admin',
             'email' => 'admin@ehb.be',
             'password' => bcrypt('Password!321'),
             'role' => User::ADMIN,


### PR DESCRIPTION
User.php (model) saves 'username'

migration has a username column too

UserSeeder makes a user have a random and unique username, admin gets the username 'admin'

I will work on the login and register and make sure that a user has to have a username to make an account, I will keep the default given by breeze to login (email + password, I might add the ability to login with: username + password)